### PR TITLE
Table no table hybrid

### DIFF
--- a/app/assets/stylesheets/foostyle.css
+++ b/app/assets/stylesheets/foostyle.css
@@ -180,23 +180,16 @@ hr {
 table {
     table-layout: fixed;
     border: none;
-    border-collapse: separate;
+    border-collapse: collapse;
     border-spacing: 0px;
-    width: 334px;
-    margin-left: 13px;
-    background-color: #ffffff;
-    align-items: center;
+    width: 100%;
+    #margin-left: 13px;
+    #align-items: center;
 }
 
-.table-btn {
-    padding: 9px 0px 9px 0px;
-    border-top-right-radius: 3px !important;
-    border-top-left-radius: 3px !important;
-}
-
-.table-content {
-    border-bottom-right-radius: 3px !important;
-    border-bottom-left-radius: 3px !important;
+.table-thumbnail-content {
+    background-size: 100% auto;
+    background-position: 0px -40px;
 }
 
 table td:hover img.inactive {
@@ -211,26 +204,12 @@ td {
     border-top: none !important;
     padding: 0 !important;
     max-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 td.col-left {
-    width: 12%;
-    padding: 0;
+    width: 10%;
 }
 
 td.col-right {
-    width: 88%;
-}
-
-
-tr {
-    border-color: #000001;
-    padding: 0px;
-}
-
-tr.background {
-    width: 100%;
+    width: 90%;
 }

--- a/app/assets/stylesheets/foostyle.css
+++ b/app/assets/stylesheets/foostyle.css
@@ -68,6 +68,10 @@
     padding-left: 0 !important;
 }
 
+.col-index {
+    padding: 1px 0px 0px 25px;
+}
+
 .headline-text {
     font-weight: bold;
     font-size: 13px;
@@ -88,6 +92,7 @@
 
 .main-page-inner {
     background-color: #ffffff;
+    margin-top: 10px;
     padding: 10px;
     align-items: center;
     border-radius: 3px
@@ -116,6 +121,10 @@
 /*  ____________________   */
 /*   Overriding Defaults   */
 /*  ____________________   */
+
+body {
+    background-color: #000001;
+}
 
 h5 {
     color: #FFFFFF;

--- a/app/assets/stylesheets/foostyle.css
+++ b/app/assets/stylesheets/foostyle.css
@@ -75,7 +75,11 @@
 .headline-text {
     font-weight: bold;
     font-size: 13px;
-    margin-top: 2px;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0px 0px 0px 0px;
 }
 
 .main-page {
@@ -102,10 +106,27 @@
     background-color: #191D20;
 }
 
+.bottom-right-border {
+    border-bottom: solid 1px #DED9DA;
+    width: 90%;
+}
+
+.bottom-left-border {
+    border-bottom: solid 1px #E9E9E9;
+}
+
+.bottom-last-border {
+    border-bottom: none;
+}
+
 .subheadline-text {
     font-size: 13px;
     color: #7D7D7D;
     padding-bottom: 4px;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .title-text {
@@ -204,17 +225,6 @@ td.col-right {
     width: 88%;
 }
 
-td.row-bottom-right {
-    border-bottom: solid 1px #DED9DA;
-}
-
-td.row-bottom-left {
-    border-bottom: solid 1px #E9E9E9;
-}
-
-td.row-bottom-last {
-    border-bottom: none;
-}
 
 tr {
     border-color: #000001;

--- a/app/assets/stylesheets/foostyle.css
+++ b/app/assets/stylesheets/foostyle.css
@@ -58,6 +58,11 @@
     padding: 4px 55px 4px 40px;
 }
 
+.btn-row {
+    margin-top: 4px;
+    margin-bottom: 16px;
+}
+
 .container-left-align {
     margin-left: 0 !important;
     padding-left: 0 !important;
@@ -108,7 +113,6 @@
 
 .bottom-right-border {
     border-bottom: solid 1px #DED9DA;
-    width: 90%;
 }
 
 .bottom-left-border {

--- a/app/views/post/articles.erb
+++ b/app/views/post/articles.erb
@@ -1,7 +1,7 @@
 <div class="col-lg-3 col-md-3"></div>
 <div class=" main-page-inner container col-lg-5 col-md-5">
   <!-- Navigation Buttons -->
-  <div class="row" align="center">
+  <div class="row btn-row" align="center">
     <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
       <%= link_to "Articles", articles_path, class: "btn-active btn-left" %><!--
     !--><%= link_to "Videos", videos_path, class: "btn-inactive btn-right" %>
@@ -22,8 +22,8 @@
               </td>
             </tr>
             <tr>
-              <td></td>
-              <td class="subheadline-text">
+              <td class="bottom-left-border"></td>
+              <td class="subheadline-text bottom-right-border">
                 <%= post.postable.subHeadline.nil? ? "&nbsp;".html_safe : post.postable.subHeadline %>
               </td>
             </tr>

--- a/app/views/post/articles.erb
+++ b/app/views/post/articles.erb
@@ -1,26 +1,28 @@
-<div class="main-page col-lg-3 col-md-3 col-sm-6 col-xs-12">
-  <div class="container">
-    <!-- Navigation Buttons -->
-    <div class="row">
+<div class="col-lg-3 col-md-3"></div>
+<div class=" main-page-inner container col-lg-5 col-md-5">
+  <!-- Navigation Buttons -->
+  <div class="row" align="center">
+    <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
       <%= link_to "Articles", articles_path, class: "btn-active btn-left" %><!--
     !--><%= link_to "Videos", videos_path, class: "btn-inactive btn-right" %>
     </div>
+  </div>
 
-    <!-- Content -->
-    <% @arr.each do |post, index| %>
-        <div class="row" style="background-image:url(<%#= post.thumbnail %>);">
-          <div class="col-index col-lg-1 col-md-1 col-sm-1 col-xs-1">
-            <%= sprintf '%02d', index %>
+  <!-- Content -->
+  <% @arr.each do |post, index| %>
+      <div class="row" style="background-image:url(<%#= post.thumbnail %>);">
+        <div class="col-index col-lg-1 col-md-1 col-sm-1 col-xs-1">
+          <%= sprintf '%02d', index %>
+        </div>
+        <div class="col-content col-lg-11 col-md-11 col-sm-11 col-xs-11">
+          <div class="row headline-text">
+            <%= post.postable.headline %>
           </div>
-          <div class="col-content col-lg-11 col-md-11 col-sm-11 col-xs-11">
-            <div class="row headline-text">
-              <%= truncate post.postable.headline, length: 34, separator: ' ' %>
-            </div>
-            <div class="row subheadline-text">
-              <%= post.postable.subHeadline.nil? ? "&nbsp;".html_safe : truncate(post.postable.subHeadline, length: 32) %>
-            </div>
+          <div class="row subheadline-text">
+            <%= post.postable.subHeadline.nil? ? "&nbsp;".html_safe : post.postable.subHeadline %>
           </div>
         </div>
-    <% end %>
-  </div>
+      </div>
+  <% end %>
 </div>
+<div class="col-lg-4 col-md-4"></div>

--- a/app/views/post/articles.erb
+++ b/app/views/post/articles.erb
@@ -11,14 +11,18 @@
   <!-- Content -->
   <% @arr.each do |post, index| %>
       <div class="row" style="background-image:url(<%#= post.thumbnail %>);">
-        <div class="col-index col-lg-1 col-md-1 col-sm-1 col-xs-1">
-          <%= sprintf '%02d', index %>
+        <div class="col-index bottom-left-border col-lg-1 col-md-1 col-sm-1 col-xs-1">
+          <div class="row">
+            <%= sprintf '%02d', index %>
+            <br/>
+            <br/>
+          </div>
         </div>
         <div class="col-content col-lg-11 col-md-11 col-sm-11 col-xs-11">
           <div class="row headline-text">
             <%= post.postable.headline %>
           </div>
-          <div class="row subheadline-text">
+          <div class="row subheadline-text bottom-right-border">
             <%= post.postable.subHeadline.nil? ? "&nbsp;".html_safe : post.postable.subHeadline %>
           </div>
         </div>

--- a/app/views/post/articles.erb
+++ b/app/views/post/articles.erb
@@ -1,37 +1,24 @@
-<div class="container main-page col-md-3 col-sm-3 col-xs-12">
+<div class="container main-page col-lg-3 col-md-3 col-sm-6 col-xs-12">
+  <!-- Navigation Buttons -->
   <div class="row">
-    <table class="table-btn">
-      <tr>
-        <td colspan="2" align="center">
-          <%= link_to "Articles", articles_path, class: "btn-active btn-left" %><!--
-            !--><%= link_to "Videos", videos_path, class: "btn-inactive btn-right" %>
-        </td>
-      </tr>
-    </table>
-    <table class="table-content">
-      <% @arr.each do |post, index| %>
-
-          <!-- style='background-image: url(<%= %>); background-repeat:no-repeat; width: 100%;'-->
-          <tr>
-            <td class="col-left row-bottom-left" align="center">
-              <div class="table-index"><%= sprintf '%02d', index %></div>
-            </td>
-            <td class="col-right row-bottom-right" align="left">
-              <div class="headline-text">
-                <%= truncate post.postable.headline, length: 34, separator: ' ' %></br>
-              </div>
-              <div class="subheadline-text">
-                <%= post.postable.subHeadline.nil? ? "&nbsp;".html_safe : truncate(post.postable.subHeadline, length: 32) %>
-              </div>
-            </td>
-            <td>
-
-            </td>
-
-            <%= image_tag post.thumbnail, class: 'tr-row' %>
-          </tr>
-      <% end %>
-    </table>
+    <%= link_to "Articles", articles_path, class: "btn-active btn-left" %><!--
+    !--><%= link_to "Videos", videos_path, class: "btn-inactive btn-right" %>
   </div>
+
+  <!-- Content -->
+  <% @arr.each do |post, index| %>
+      <div class="row" style="background-image:url(<%= post.thumbnail %>);">
+        <div class="col-index">
+          <%= sprintf '%02d', index %>
+        </div>
+        <div class="col-content">
+          <div class="headline-text">
+            <%= truncate post.postable.headline, length: 34, separator: ' ' %></br>
+          </div>
+          <div class="subheadline-text">
+            <%= post.postable.subHeadline.nil? ? "&nbsp;".html_safe : truncate(post.postable.subHeadline, length: 32) %>
+          </div>
+        </div>
+      </div>
+  <% end %>
 </div>
-<div class="col-md-9 col-xs-3"></div>

--- a/app/views/post/articles.erb
+++ b/app/views/post/articles.erb
@@ -1,24 +1,26 @@
-<div class="container main-page col-lg-3 col-md-3 col-sm-6 col-xs-12">
-  <!-- Navigation Buttons -->
-  <div class="row">
-    <%= link_to "Articles", articles_path, class: "btn-active btn-left" %><!--
+<div class="main-page col-lg-3 col-md-3 col-sm-6 col-xs-12">
+  <div class="container">
+    <!-- Navigation Buttons -->
+    <div class="row">
+      <%= link_to "Articles", articles_path, class: "btn-active btn-left" %><!--
     !--><%= link_to "Videos", videos_path, class: "btn-inactive btn-right" %>
-  </div>
+    </div>
 
-  <!-- Content -->
-  <% @arr.each do |post, index| %>
-      <div class="row" style="background-image:url(<%= post.thumbnail %>);">
-        <div class="col-index">
-          <%= sprintf '%02d', index %>
-        </div>
-        <div class="col-content">
-          <div class="headline-text">
-            <%= truncate post.postable.headline, length: 34, separator: ' ' %></br>
+    <!-- Content -->
+    <% @arr.each do |post, index| %>
+        <div class="row" style="background-image:url(<%#= post.thumbnail %>);">
+          <div class="col-index col-lg-1 col-md-1 col-sm-1 col-xs-1">
+            <%= sprintf '%02d', index %>
           </div>
-          <div class="subheadline-text">
-            <%= post.postable.subHeadline.nil? ? "&nbsp;".html_safe : truncate(post.postable.subHeadline, length: 32) %>
+          <div class="col-content col-lg-11 col-md-11 col-sm-11 col-xs-11">
+            <div class="row headline-text">
+              <%= truncate post.postable.headline, length: 34, separator: ' ' %>
+            </div>
+            <div class="row subheadline-text">
+              <%= post.postable.subHeadline.nil? ? "&nbsp;".html_safe : truncate(post.postable.subHeadline, length: 32) %>
+            </div>
           </div>
         </div>
-      </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/post/articles.erb
+++ b/app/views/post/articles.erb
@@ -10,22 +10,26 @@
 
   <!-- Content -->
   <% @arr.each do |post, index| %>
-      <div class="row" style="background-image:url(<%#= post.thumbnail %>);">
-        <div class="col-index bottom-left-border col-lg-1 col-md-1 col-sm-1 col-xs-1">
-          <div class="row">
-            <%= sprintf '%02d', index %>
-            <br/>
-            <br/>
-          </div>
+      <div class="row" align="center">
+        <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
+          <table>
+            <tr>
+              <td class="col-left table-index">
+                <%= sprintf '%02d', index %>
+              </td>
+              <td>
+                <div class="col-right headline-text"><%= post.postable.headline %></div>
+              </td>
+            </tr>
+            <tr>
+              <td></td>
+              <td class="subheadline-text">
+                <%= post.postable.subHeadline.nil? ? "&nbsp;".html_safe : post.postable.subHeadline %>
+              </td>
+            </tr>
+          </table>
         </div>
-        <div class="col-content col-lg-11 col-md-11 col-sm-11 col-xs-11">
-          <div class="row headline-text">
-            <%= post.postable.headline %>
-          </div>
-          <div class="row subheadline-text bottom-right-border">
-            <%= post.postable.subHeadline.nil? ? "&nbsp;".html_safe : post.postable.subHeadline %>
-          </div>
-        </div>
+
       </div>
   <% end %>
 </div>


### PR DESCRIPTION
This replaces the full table concept and the branch with no tables (only bootstrap columns) and makes a hybrid of both in one. The reason for this is to allow background pictures to elegantly be displayed in table rows and allow to be manipulated easily. You are not able to do background-image modifications as flexibly outside of tables, that is why I chose to go this way.
